### PR TITLE
Create Grounded.md

### DIFF
--- a/語言模型/Grounded.md
+++ b/語言模型/Grounded.md
@@ -1,0 +1,35 @@
+# Grounded
+
+## Ray: ground probability in Bayesian probability
+
+When discussing probability within a Bayesian framework, it's crucial to understand the role of "prior probability." While "ground probability" isn't a standard, formal term, the concept it might allude to is closely tied to the idea of a prior. Here's a breakdown:
+
+**Bayesian Probability Basics:**
+
+* **Bayesian probability** interprets probability as a degree of belief or confidence in an event, rather than just the frequency of its occurrence.
+* It uses Bayes' theorem to update these beliefs as new evidence becomes available.
+
+**Key Concepts:**
+
+* **Prior Probability:**
+    * This is your initial belief about the probability of an event before you observe any new data.
+    * It represents your existing knowledge or assumptions.
+    * It can be based on past experiences, expert opinions, or theoretical considerations.
+* **Posterior Probability:**
+    * This is the updated probability of an event after you've considered new evidence.
+    * It's calculated by combining the prior probability with the likelihood of the observed data.
+* **Bayes' Theorem:**
+    * This mathematical formula provides the framework for updating prior probabilities to obtain posterior probabilities.
+
+**Relating to "Ground Probability":**
+
+* If "ground probability" were to be interpreted, it might refer to the foundational or initial probability you start with. In the Bayesian context, that would be the prior probability.
+* The prior can be thought of as the "ground" upon which you build your updated understanding.
+
+**In essence:**
+
+* Bayesian probability is about updating your beliefs.
+* The prior probability is the starting point of those beliefs.
+* New evidence leads to the calculation of the posterior probability, which is the revised belief.
+
+Therefore, while "ground probability" isn't a standard term, its meaning is very close to the standard term "prior probability".


### PR DESCRIPTION
# Grounded

## Ray: ground probability in Bayesian probability

When discussing probability within a Bayesian framework, it's crucial to understand the role of "prior probability." While "ground probability" isn't a standard, formal term, the concept it might allude to is closely tied to the idea of a prior. Here's a breakdown:

**Bayesian Probability Basics:**

* **Bayesian probability** interprets probability as a degree of belief or confidence in an event, rather than just the frequency of its occurrence.
* It uses Bayes' theorem to update these beliefs as new evidence becomes available.

**Key Concepts:**

* **Prior Probability:**
    * This is your initial belief about the probability of an event before you observe any new data.
    * It represents your existing knowledge or assumptions.
    * It can be based on past experiences, expert opinions, or theoretical considerations.
* **Posterior Probability:**
    * This is the updated probability of an event after you've considered new evidence.
    * It's calculated by combining the prior probability with the likelihood of the observed data.
* **Bayes' Theorem:**
    * This mathematical formula provides the framework for updating prior probabilities to obtain posterior probabilities.

**Relating to "Ground Probability":**

* If "ground probability" were to be interpreted, it might refer to the foundational or initial probability you start with. In the Bayesian context, that would be the prior probability.
* The prior can be thought of as the "ground" upon which you build your updated understanding.

**In essence:**

* Bayesian probability is about updating your beliefs.
* The prior probability is the starting point of those beliefs.
* New evidence leads to the calculation of the posterior probability, which is the revised belief.

Therefore, while "ground probability" isn't a standard term, its meaning is very close to the standard term "prior probability".